### PR TITLE
chore: pin terraform version in GitHub linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 0.12.26
 
     - name: terraform fmt
       run: terraform fmt -check -recursive -diff


### PR DESCRIPTION
0.13.0 is in beta, which is being automatically selected if a version
isn't defined for the `setup-terraform` Action.

This makes sure we're good.