### PR TITLE
improvement: output ASG tags from cluster-autoscaler

### DIFF
--- a/modules/cluster-autoscaler/outputs.tf
+++ b/modules/cluster-autoscaler/outputs.tf
@@ -1,0 +1,4 @@
+output "asg_tags" {
+  description = "Tags which must be added to the auto-scaling groups for the cluster-autoscaler to consider."
+  value       = local.asg_tags
+}


### PR DESCRIPTION
Previously, you'd have to hard-code tags on the ASGs you wanted `cluster-autoscaler` to consider. This PR outputs the tags needed for the ASGs.

No more hard-coding :tada: 