### PR TITLE
add-port-testing-module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ override.tf.json
 
 *.swp
 
+# Jetbrains
+**/.idea/*

--- a/modules/port-tester/README.md
+++ b/modules/port-tester/README.md
@@ -1,8 +1,13 @@
 # Port testing Addon
-Very simple go webserver that executes a HTTP GET against a
+Very simple go webserver that executes an HTTP GET against a
 provided endpoint and tests for an expected returned status code
 
 This application doesn't do any testing itself, it will only execute
-what you want it to. An expect use is to config a dashboard like grafana
-to, on a schedule, hit an endpoint and check the response. Populate the
-influx with the result and display the data on the dashboard.
+what you want it to. An expected use is to config a dashboard like grafana
+to poll endpoints and check the response.
+
+## Example
+
+```shell script
+curl "http://HOST/?endpoint=https://rancher.lqd.dk&expectedStatusCode=200"
+```

--- a/modules/port-tester/README.md
+++ b/modules/port-tester/README.md
@@ -1,0 +1,8 @@
+# Port testing Addon
+Very simple go webserver that executes a HTTP GET against a
+provided endpoint and tests for an expected returned status code
+
+This application doesn't do any testing itself, it will only execute
+what you want it to. An expect use is to config a dashboard like grafana
+to, on a schedule, hit an endpoint and check the response. Populate the
+influx with the result and display the data on the dashboard.

--- a/modules/port-tester/main.tf
+++ b/modules/port-tester/main.tf
@@ -2,6 +2,7 @@ locals {
   chart_name    = "port-tester"
   chart_version = var.chart_version
   release_name  = "port-tester"
+  namespace     = var.namespace
   repository    = "https://harbor.aws.c.dk/chartrepo/shared-platforms"
 }
 
@@ -11,4 +12,6 @@ resource "helm_release" "port-tester" {
   chart      = local.chart_name
   version    = local.chart_version
   repository = local.repository
+  namespace  = local.namespace
+  create_namespace = true
 }

--- a/modules/port-tester/main.tf
+++ b/modules/port-tester/main.tf
@@ -1,9 +1,26 @@
+resource "kubernetes_namespace" "this" {
+  count = var.create_namespace == true ? 1 : 0
+
+  metadata {
+    name = var.namespace
+
+    annotations = {
+      managedby = "terraform"
+    }
+  }
+}
+
 locals {
   chart_name    = "port-tester"
   chart_version = var.chart_version
   release_name  = "port-tester"
-  namespace     = var.namespace
   repository    = "https://harbor.aws.c.dk/chartrepo/shared-platforms"
+  create_namespace = true
+
+  values = {
+    namespace = var.namespace
+    name = "port-tester"
+  }
 }
 
 resource "helm_release" "port-tester" {
@@ -12,6 +29,10 @@ resource "helm_release" "port-tester" {
   chart      = local.chart_name
   version    = local.chart_version
   repository = local.repository
-  namespace  = local.namespace
-  create_namespace = true
+  namespace  = var.namespace
+  values     = [yamlencode(local.values)]
+
+  depends_on = [
+    kubernetes_namespace.this,
+  ]
 }

--- a/modules/port-tester/main.tf
+++ b/modules/port-tester/main.tf
@@ -2,7 +2,6 @@ locals {
   chart_name    = "port-tester"
   chart_version = var.chart_version
   release_name  = "port-tester"
-  namespace     = var.namespace
   repository    = "https://harbor.aws.c.dk/chartrepo/shared-platforms"
 }
 
@@ -12,5 +11,4 @@ resource "helm_release" "port-tester" {
   chart      = local.chart_name
   version    = local.chart_version
   repository = local.repository
-  namespace  = local.namespace
 }

--- a/modules/port-tester/main.tf
+++ b/modules/port-tester/main.tf
@@ -11,15 +11,15 @@ resource "kubernetes_namespace" "this" {
 }
 
 locals {
-  chart_name    = "port-tester"
-  chart_version = var.chart_version
-  release_name  = "port-tester"
-  repository    = "https://harbor.aws.c.dk/chartrepo/shared-platforms"
+  chart_name       = "port-tester"
+  chart_version    = var.chart_version
+  release_name     = "port-tester"
+  repository       = "https://harbor.aws.c.dk/chartrepo/shared-platforms"
   create_namespace = true
 
   values = {
     namespace = var.namespace
-    name = "port-tester"
+    name      = "port-tester"
   }
 }
 

--- a/modules/port-tester/main.tf
+++ b/modules/port-tester/main.tf
@@ -1,0 +1,16 @@
+locals {
+  chart_name    = "port-tester"
+  chart_version = var.chart_version
+  release_name  = "port-tester"
+  namespace     = var.namespace
+  repository    = "https://harbor.aws.c.dk/chartrepo/shared-platforms"
+}
+
+resource "helm_release" "port-tester" {
+  count      = var.enable ? 1 : 0
+  name       = local.release_name
+  chart      = local.chart_name
+  version    = local.chart_version
+  repository = local.repository
+  namespace  = local.namespace
+}

--- a/modules/port-tester/variables.tf
+++ b/modules/port-tester/variables.tf
@@ -1,0 +1,17 @@
+variable "chart_version" {
+  default     = "0.1.0"
+  description = "port-testing version to install"
+  type        = string
+}
+
+variable "namespace" {
+  default     = "port-testing"
+  description = "Namespace to install port-tester in"
+  type        = string
+}
+
+variable "enable" {
+  default     = false
+  description = "Enable or Disable port-testing"
+  type        = bool
+}

--- a/modules/port-tester/variables.tf
+++ b/modules/port-tester/variables.tf
@@ -1,4 +1,5 @@
 variable "chart_version" {
+  default     = "0.1.0"
   description = "port-testing version to install"
   type        = string
 }

--- a/modules/port-tester/variables.tf
+++ b/modules/port-tester/variables.tf
@@ -14,3 +14,8 @@ variable "enable" {
   description = "Enable or Disable port-testing"
   type        = bool
 }
+
+variable "create_namespace" {
+  description = "Whether to create the namespace defined in the namespace variable. Will fail if the namespace already exists"
+  default     = false
+}

--- a/modules/port-tester/variables.tf
+++ b/modules/port-tester/variables.tf
@@ -1,11 +1,9 @@
 variable "chart_version" {
-  default     = "0.1.0"
   description = "port-testing version to install"
   type        = string
 }
 
 variable "namespace" {
-  default     = "port-testing"
   description = "Namespace to install port-tester in"
   type        = string
 }


### PR DESCRIPTION
Added the port testing module. This installs a simple server that dashboards can poll to confirm port openings on the internal firewall