### PR TITLE
chore: prefix version tags with 'v'

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v4.1
         id: version
         with:
-          tag_prefix: ""
+          tag_prefix: "v"
           dry_run: true
           default_bump: patch
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This ensures consistency with previous tags in this repository, and the general way of tagging versions in the community.

Examples
- https://github.com/terraform-aws-modules/terraform-aws-vpc/tags
- https://github.com/terraform-aws-modules/terraform-aws-eks/tags