### PR TITLE
feat: accept Route53 zone IDs instead of names for External DNS domain filters

### DIFF
--- a/modules/external-dns/variables.tf
+++ b/modules/external-dns/variables.tf
@@ -4,9 +4,16 @@ variable "enable" {
   type        = bool
 }
 
+variable "route53_zones" {
+  type        = list(string)
+  description = "List of Route53 zones for external-dns to work with. NOTE: This is mutually exclusive to 'route53_zone_ids'."
+  default     = []
+}
+
 variable "route53_zone_ids" {
   type        = list(string)
-  description = "List of Route53 zone IDs for external-dns to work with."
+  description = "List of Route53 zone IDs for external-dns to work with. NOTE: This is mutually exclusive to 'route53_zones'."
+  default     = []
 }
 
 variable "chart_version" {

--- a/modules/external-dns/variables.tf
+++ b/modules/external-dns/variables.tf
@@ -4,9 +4,9 @@ variable "enable" {
   type        = bool
 }
 
-variable "route53_zones" {
+variable "route53_zone_ids" {
   type        = list(string)
-  description = "List of Route53 zone names for external-dns to work with."
+  description = "List of Route53 zone IDs for external-dns to work with."
 }
 
 variable "chart_version" {


### PR DESCRIPTION
Previously, the external-dns add-on would look up the zones by name using `data.aws_route53_zone`. While elegant, this required the default AWS provider to be able to access the Route53 zone.

This isn't always possible, and passing in the zone IDs instead works for all the cases.

**Note** This is a breaking change.