### PR TITLE
improvement: auth against EKS using kubectl --server and --token parameters

### DIFF
--- a/modules/cert-manager/main.tf
+++ b/modules/cert-manager/main.tf
@@ -195,14 +195,13 @@ resource "null_resource" "aws_iam_cluster_issuer" {
 
   provisioner "local-exec" {
     command = <<EOF
-cat <<MOF | kubectl --token ${var.kubectl_token} apply -f -
+cat <<MOF | kubectl \
+  --token ${var.kubectl_token} \
+  --server ${var.kubectl_server} \
+    apply -f -
 ${yamlencode(local.manifest_cluster_issuer_staging)}
 MOF
 EOF
-
-    environment = {
-      KUBECONFIG = "${var.kubeconfig_filename}"
-    }
   }
 
   depends_on = [time_sleep.wait_30_seconds]
@@ -218,15 +217,14 @@ resource "null_resource" "aws_iam_cluster_issuer_production" {
 
   provisioner "local-exec" {
     command = <<EOF
-cat <<MOF | kubectl --token ${var.kubectl_token} apply -f -
+cat <<MOF | kubectl \
+  --token ${var.kubectl_token} \
+  --server ${var.kubectl_server} \
+    apply -f -
 ${yamlencode(local.manifest_cluster_issuer_production)}
 MOF
 EOF
-
-    environment = {
-      KUBECONFIG = "${var.kubeconfig_filename}"
-    }
   }
-  depends_on = [time_sleep.wait_30_seconds]
 
+  depends_on = [time_sleep.wait_30_seconds]
 }

--- a/modules/cert-manager/variables.tf
+++ b/modules/cert-manager/variables.tf
@@ -28,8 +28,9 @@ variable "ingress_class" {
   type = string
 }
 
-variable "kubeconfig_filename" {
-  type = string
+variable "kubectl_server" {
+  description = "Hostname of the EKS control plane. This will be passed to `kubectl --server $here`."
+  type        = string
 }
 
 variable "kubectl_token" {


### PR DESCRIPTION
This is way neater than using a `kubeconfig` file when addressing the EKS API servers using `kubectl`.