### PR TITLE
fix: ignore EKS CA when running kubectl for Cert Manager

### DIFF
--- a/modules/cert-manager/main.tf
+++ b/modules/cert-manager/main.tf
@@ -123,6 +123,7 @@ resource "random_id" "cert_manager" {
   keepers = {
     provider_url = local.provider_url
   }
+
   byte_length = 16
 }
 
@@ -196,6 +197,7 @@ resource "null_resource" "aws_iam_cluster_issuer" {
   provisioner "local-exec" {
     command = <<EOF
 cat <<MOF | kubectl \
+  --insecure-skip-tls-verify \
   --token ${var.kubectl_token} \
   --server ${var.kubectl_server} \
     apply -f -
@@ -218,6 +220,7 @@ resource "null_resource" "aws_iam_cluster_issuer_production" {
   provisioner "local-exec" {
     command = <<EOF
 cat <<MOF | kubectl \
+  --insecure-skip-tls-verify \
   --token ${var.kubectl_token} \
   --server ${var.kubectl_server} \
     apply -f -


### PR DESCRIPTION
Errors like these can appear if `~/.kube/config` contains
a context for the same cluster:

    Unable to connect to the server: x509: certificate signed by unknown
    authority (possibly because of "crypto/rsa: verification error"
    while trying to verify candidate authority certificate "kubernetes"

Adding `--insecure-skip-tls-verify` prevents this from happening.