### PR TITLE
feat: add AWS EFS CSI driver add-on module

### DIFF
--- a/modules/aws-efs-csi-driver/main.tf
+++ b/modules/aws-efs-csi-driver/main.tf
@@ -1,0 +1,8 @@
+resource "helm_release" "this" {
+  count      = var.enable ? 1 : 0
+  name       = "aws-efs-csi-driver"
+  chart      = "aws-efs-csi-driver"
+  version    = var.chart_version
+  repository = "https://kubernetes-sigs.github.io/aws-efs-csi-driver/"
+  wait       = true
+}

--- a/modules/aws-efs-csi-driver/variables.tf
+++ b/modules/aws-efs-csi-driver/variables.tf
@@ -1,0 +1,11 @@
+variable "chart_version" {
+  default     = "0.1.0"
+  description = "aws-efs-csi-driver version"
+  type        = string
+}
+
+variable "enable" {
+  default     = true
+  description = "Whether aws-efs-csi-driver should be installed or not."
+  type        = bool
+}


### PR DESCRIPTION
This allows us to use [AWS EFS](https://aws.amazon.com/efs/) in our persistent storage inside EKS.
In contrast, EBS is cheaper but also local to the AZ it's provisioned in whereas EFS spans AZs.

References:

- https://github.com/kubernetes-sigs/aws-efs-csi-driver
- https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html