### PR TITLE
fix(loki): Changed logic around creating the loki namespace.

### DIFF
--- a/modules/loki/main.tf
+++ b/modules/loki/main.tf
@@ -190,11 +190,8 @@ module "s3_bucket" {
 
 }
 
-data "kubernetes_all_namespaces" "all" {}
-
 resource "kubernetes_namespace" "this" {
-  count = contains(data.kubernetes_all_namespaces.all.namespaces, local.namespace) ? 0 : 1
-
+  count = var.create_namespace == true ? 1 : 0
   metadata {
     name = local.namespace
   }

--- a/modules/loki/variables.tf
+++ b/modules/loki/variables.tf
@@ -21,6 +21,10 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "create_namespace" {
+  description = "Whether to create the namespace defined in the namespace variable. Will fail if the namespace already exists."
+  default     = false
+}
 
 variable "oidc_provider_issuer_url" {
   description = "Issuer used in the OIDC provider associated with the EKS cluster to support IRSA."


### PR DESCRIPTION
the current way results in `terraform-aws-eks` because the cluster has not been created yet.
changing the logic by removing the data field solves this issue