### PR TITLE
improvement: Increase loki namespace deletion timeout

### DIFF
--- a/modules/loki/main.tf
+++ b/modules/loki/main.tf
@@ -208,8 +208,13 @@ module "s3_bucket" {
 
 resource "kubernetes_namespace" "this" {
   count = var.create_namespace == true ? 1 : 0
+
   metadata {
     name = local.namespace
+  }
+
+  timeouts {
+    delete = "10m"
   }
 }
 


### PR DESCRIPTION
The loki namespace can take a while to destroy. Increasing the delete timeout.