### PR TITLE
fix(loki): Enable ondemand throughput mode, since autoscaling config wasnt effective

### DIFF
--- a/modules/loki/main.tf
+++ b/modules/loki/main.tf
@@ -71,19 +71,8 @@ locals {
           retention_period = "${var.retention_days * 24}h"
 
           index_tables_provisioning = {
-            provisioned_write_throughput = 1
-            provisioned_read_throughput  = 1
-
-            write_scale = {
-              enabled      = true
-              min_capacity = 1
-              role_arn     = module.iam.this_iam_role_arn
-            }
-            read_scale = {
-              enabled      = true
-              min_capacity = 1
-              role_arn     = module.iam.this_iam_role_arn
-            }
+            enable_ondemand_throughput_mode = true
+            enable_inactive_throughput_on_demand_mode = true
           }
         }
       }

--- a/modules/loki/main.tf
+++ b/modules/loki/main.tf
@@ -71,7 +71,7 @@ locals {
           retention_period = "${var.retention_days * 24}h"
 
           index_tables_provisioning = {
-            enable_ondemand_throughput_mode = true
+            enable_ondemand_throughput_mode           = true
             enable_inactive_throughput_on_demand_mode = true
           }
         }


### PR DESCRIPTION
It looks like autoscaling config isn't deployed to AWS, and rather than finding out why, I propose just switching to ondemand mode until we move to Loki 2.0 and use boltdb-shipper to get rid of dynamodb