### PR TITLE
feat: Add variable to insure the validity of incoming ingress object

### DIFF
--- a/modules/nginx-ingress-controller/main.tf
+++ b/modules/nginx-ingress-controller/main.tf
@@ -72,6 +72,10 @@ locals {
         }
       }
 
+      admissionWebhooks = {
+        enabled = var.admission_webhooks
+      }
+
       extraArgs = {
         "publish-status-address" = var.loadbalancer_fqdn
       }

--- a/modules/nginx-ingress-controller/variables.tf
+++ b/modules/nginx-ingress-controller/variables.tf
@@ -70,3 +70,8 @@ variable "wait" {
   description = "Whether to wait for the deployment of this add-on to succeed before completing."
   default     = true
 }
+
+variable "admission_webhooks" {
+  description = "Ensure the validity of incoming ingress objects to avoid downtimes in case developers use invalid configuration for the ingress objects."
+  default     = false
+}


### PR DESCRIPTION
feat: add variable to insure the validity of incoming ingress objects in case developers use invalid configuration for the ingress objects (K8-180)