### PR TITLE
fix: upgrade iam-assumable-role-with-oidc to 3.9.0 to make it compatible with terraform 0.14.7

### DIFF
--- a/modules/cert-manager/main.tf
+++ b/modules/cert-manager/main.tf
@@ -164,7 +164,7 @@ module "iam" {
   # source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role-with-oidc?ref=v2.14.0"
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version = "3.6.0"
+  version = "3.9.0"
 
   create_role                   = var.enable
   role_name                     = "${local.release_name}-irsa-${random_id.cert_manager.hex}"

--- a/modules/external-dns/main.tf
+++ b/modules/external-dns/main.tf
@@ -55,7 +55,7 @@ resource "random_id" "external_dns" {
 module "iam" {
   # source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role-with-oidc?ref=v2.14.0"
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version = "3.6.0"
+  version = "3.9.0"
 
   create_role                   = var.enable
   role_name                     = "${local.release_name}-irsa-${random_id.external_dns.hex}"


### PR DESCRIPTION
To upgrade to terraform 0.14.7 there is a lot of version numbers that needs to be updated. This is the first one.